### PR TITLE
Fixed 2 compiler warnings of this type: String interpolation produces…

### DIFF
--- a/Sources/AuthHandlersJSON.swift
+++ b/Sources/AuthHandlersJSON.swift
@@ -248,7 +248,9 @@ public class AuthHandlersJSON {
 		var resp = [String: String]()
 
 		resp["authenticated"] = "AUTHED: \(request.user.authenticated)"
-		resp["authDetails"] = "DETAILS: \(request.user.authDetails)"
+		
+		let authDetailsValue: String = String(describing: request.user.authDetails)
+		resp["authDetails"] = "DETAILS: \(authDetailsValue)"
 
 
 		do {

--- a/Sources/AuthHandlersWeb.swift
+++ b/Sources/AuthHandlersWeb.swift
@@ -109,7 +109,7 @@ public class AuthHandlersWeb {
 	/// Handles the request for a "logout" route
 	open static func logoutHandler(request: HTTPRequest, _ response: HTTPResponse) {
 		response.addCookie(HTTPCookie(name: "TurnstileSession",
-									value: "\(request.user.authDetails?.sessionID)",
+									value: request.user.authDetails?.sessionID ?? "",
 									domain: nil,
 									expires: .relativeSeconds(-1),
 									path: "/",


### PR DESCRIPTION
… a debug description for an optional value; did you mean to make this explicit? Use 'String(describing:)' to silence this warning, Provide a default value to avoid this warning